### PR TITLE
Refactor react-router state to be passed as props to the components

### DIFF
--- a/app/components/App.js
+++ b/app/components/App.js
@@ -8,7 +8,7 @@ class App extends React.Component {
     return (
       <div>
         <Navbar />
-        <RouteHandler />
+        <RouteHandler {...this.props}/>
         <Footer />
       </div>
     );

--- a/app/components/Character.js
+++ b/app/components/Character.js
@@ -71,8 +71,4 @@ class Character extends React.Component {
   }
 }
 
-Character.contextTypes = {
-  router: React.PropTypes.func.isRequired
-};
-
 export default Character;

--- a/app/components/CharacterList.js
+++ b/app/components/CharacterList.js
@@ -66,8 +66,4 @@ class CharacterList extends React.Component {
   }
 }
 
-CharacterList.contextTypes = {
-  router: React.PropTypes.func.isRequired
-};
-
 export default CharacterList;

--- a/app/components/Navbar.js
+++ b/app/components/Navbar.js
@@ -215,8 +215,4 @@ class Navbar extends React.Component {
   }
 }
 
-Navbar.contextTypes = {
-  router: React.PropTypes.func.isRequired
-};
-
 export default Navbar;

--- a/app/main.js
+++ b/app/main.js
@@ -2,6 +2,6 @@ import React from 'react';
 import Router from 'react-router';
 import routes from './routes';
 
-Router.run(routes, Router.HistoryLocation, function(Handler) {
-  React.render(<Handler />, document.getElementById('app'));
+Router.run(routes, Router.HistoryLocation, (Handler, state) => {
+  React.render(<Handler {...state} />, document.getElementById('app'));
 });


### PR DESCRIPTION
Hi, @sahat! First of all, great work with the tutorial and thank you for the great work you shared! It provided me with very important understanding of linking all the components of a modern web app.

While working on the tutorial I thought about the way react-router props are passed to the components. With this PR I suggest an approach that does not touch the contextTypes of components (as suggested [here](https://github.com/rackt/react-router/blob/master/UPGRADE_GUIDE.md). 

It is just a suggestion of another way that the router props can be passed down.

Thanks again!
